### PR TITLE
Fix dependency on rails/test_unit/sub_test_task (drapergem#681)

### DIFF
--- a/lib/draper/tasks/test.rake
+++ b/lib/draper/tasks/test.rake
@@ -1,6 +1,6 @@
 require 'rake/testtask'
 
-test_task = if Rails.version.to_f < 3.2
+test_task = if Rails.version.to_f < 3.2 || Rails.version.start_with?('5')
   require 'rails/test_unit/railtie'
   Rake::TestTask
 else

--- a/lib/draper/view_context/build_strategy.rb
+++ b/lib/draper/view_context/build_strategy.rb
@@ -38,7 +38,7 @@ module Draper
 
         def controller
           (Draper::ViewContext.controller || ApplicationController.new).tap do |controller|
-            controller.request ||= ActionController::TestRequest.new if defined?(ActionController::TestRequest)
+            controller.request ||= ActionController::TestRequest.create if defined?(ActionController::TestRequest)
           end
         end
       end


### PR DESCRIPTION
Merge https://github.com/audionerd/draper/tree/rails5 to fix dependency on rails/test_unit/sub_test_task,
This fixes drapergem#681

running any rake task resulted in  an `LoadError: cannot load such file -- rails/test_unit/sub_test_task`, as described in the referenced issue. This patch was done by @audionerd, i simply merged it.
